### PR TITLE
added C-language ISR-wrapping macros: tn_soft_isr(vec), tn_srs_isr(vec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,22 @@ The context switch is implemented using the core software 0 interrupt. It should
 The interrupt priority level used by the context switch interrupt should not be configured to use shadow register sets.
 
 ##Interrupts
-TNKernel-PIC32 supports nested interrupts. The kernel provides assembly-language macros for calling C-language interrupt service routines, which can use either MIPS32 or MIPS16e mode. Both software and shadow register interrupt context saving is supported:
+TNKernel-PIC32 supports nested interrupts. The kernel provides C-language macros for calling C-language interrupt service routines, which can use either MIPS32 or MIPS16e mode. Both software and shadow register interrupt context saving is supported. Usage is as follows:
+
+    /* Timer 1 interrupt handler using software interrupt context saving */
+    tn_soft_isr(_TIMER_1_VECTOR)
+    {
+       /* here is your ISR code, including clearing of interrupt flag, and so on */
+    }
+
+    /* High-priority UART interrupt handler using shadow register set */
+    tn_srs_isr(_UART_1_VECTOR)
+    {
+       /* here is your ISR code, including clearing of interrupt flag, and so on */
+    }
+
+
+Alternatively, the kernel provides assembly-language macros for calling C-language interrupt service routines:
 
     #include "tn_port_asm.h"
     

--- a/tn.h
+++ b/tn.h
@@ -306,22 +306,22 @@ extern void * tn_int_sp;                //-- Saved ISR stack pointer
 //-- v.2.7
 
 #define get_task_by_tsk_queue(que)                  \
-        que ? CONTAINING_RECORD(que, TN_TCB, task_queue) : 0
+        (que ? CONTAINING_RECORD(que, TN_TCB, task_queue) : 0)
 
 #define get_task_by_timer_queque(que)               \
-        que ? CONTAINING_RECORD(que, TN_TCB, timer_queue) : 0
+        (que ? CONTAINING_RECORD(que, TN_TCB, timer_queue) : 0)
 
 #define get_mutex_by_mutex_queque(que)              \
-        que ? CONTAINING_RECORD(que, TN_MUTEX, mutex_queue) : 0
+        (que ? CONTAINING_RECORD(que, TN_MUTEX, mutex_queue) : 0)
 
 #define get_mutex_by_wait_queque(que)               \
-        que ? CONTAINING_RECORD(que, TN_MUTEX, wait_queue) : 0
+        (que ? CONTAINING_RECORD(que, TN_MUTEX, wait_queue) : 0)
 
 #define get_task_by_block_queque(que)  \
-        que ? CONTAINING_RECORD(que, TN_TCB, block_queue) : 0
+        (que ? CONTAINING_RECORD(que, TN_TCB, block_queue) : 0)
 
 #define get_mutex_by_lock_mutex_queque(que) \
-        que ? CONTAINING_RECORD(que, TN_MUTEX, mutex_queue) : 0
+        (que ? CONTAINING_RECORD(que, TN_MUTEX, mutex_queue) : 0)
 
 
    //--- User function

--- a/tn_port.h
+++ b/tn_port.h
@@ -128,4 +128,258 @@ extern "C"  {
                 return ;
 
 
+
+
+/*----------------------------------------------------------------------------
+ * Interrupt handler wrapper macro for software context saving IPL
+ *----------------------------------------------------------------------------*/
+
+#define tn_soft_isr(vec)                                                         \
+__attribute__((__noinline__)) void _func##vec(void);                             \
+void __attribute__((naked, nomips16))__attribute__((vector(vec))) _isr##vec(void)\
+{                                                                                \
+   asm volatile(".set mips32r2");                                                \
+   asm volatile(".set nomips16");                                                \
+   asm volatile(".set noreorder");                                               \
+   asm volatile(".set noat");                                                    \
+                                                                                 \
+   asm volatile("rdpgpr  $sp, $sp");                                             \
+                                                                                 \
+   /* Increase interrupt nesting count */                                        \
+   asm volatile("lui     $k0, %hi(tn_int_nest_count)");                          \
+   asm volatile("lw      $k1, %lo(tn_int_nest_count)($k0)");                     \
+   asm volatile("addiu   $k1, $k1, 1");                                          \
+   asm volatile("sw      $k1, %lo(tn_int_nest_count)($k0)");                     \
+   asm volatile("ori     $k0, $zero, 1");                                        \
+   asm volatile("bne     $k1, $k0, 1f");                                         \
+                                                                                 \
+   /* Swap stack pointers if nesting count is one */                             \
+   asm volatile("lui     $k0, %hi(tn_user_sp)");                                 \
+   asm volatile("sw      $sp, %lo(tn_user_sp)($k0)");                            \
+   asm volatile("lui     $k0, %hi(tn_int_sp)");                                  \
+   asm volatile("lw      $sp, %lo(tn_int_sp)($k0)");                             \
+                                                                                 \
+   asm volatile("1:");                                                           \
+   /* Save context on stack */                                                   \
+   asm volatile("addiu   $sp, $sp, -92");                                        \
+   asm volatile("mfc0    $k1, $14");               /* c0_epc*/                   \
+   asm volatile("mfc0    $k0, $12, 2");            /* c0_srsctl*/                \
+   asm volatile("sw      $k1, 84($sp)");                                         \
+   asm volatile("sw      $k0, 80($sp)");                                         \
+   asm volatile("mfc0    $k1, $12");               /* c0_status*/                \
+   asm volatile("sw      $k1, 88($sp)");                                         \
+                                                                                 \
+   /* Enable nested interrupts */                                                \
+   asm volatile("mfc0    $k0, $13");               /* c0_cause*/                 \
+   asm volatile("ins     $k1, $zero, 1, 15");                                    \
+   asm volatile("ext     $k0, $k0, 10, 6");                                      \
+   asm volatile("ins     $k1, $k0, 10, 6");                                      \
+   asm volatile("mtc0    $k1, $12");               /* c0_status*/                \
+                                                                                 \
+   /* Save caller-save registers on stack */                                     \
+   asm volatile("sw      $ra, 76($sp)");                                         \
+   asm volatile("sw      $t9, 72($sp)");                                         \
+   asm volatile("sw      $t8, 68($sp)");                                         \
+   asm volatile("sw      $t7, 64($sp)");                                         \
+   asm volatile("sw      $t6, 60($sp)");                                         \
+   asm volatile("sw      $t5, 56($sp)");                                         \
+   asm volatile("sw      $t4, 52($sp)");                                         \
+   asm volatile("sw      $t3, 48($sp)");                                         \
+   asm volatile("sw      $t2, 44($sp)");                                         \
+   asm volatile("sw      $t1, 40($sp)");                                         \
+   asm volatile("sw      $t0, 36($sp)");                                         \
+   asm volatile("sw      $a3, 32($sp)");                                         \
+   asm volatile("sw      $a2, 28($sp)");                                         \
+   asm volatile("sw      $a1, 24($sp)");                                         \
+   asm volatile("sw      $a0, 20($sp)");                                         \
+   asm volatile("sw      $v1, 16($sp)");                                         \
+   asm volatile("sw      $v0, 12($sp)");                                         \
+   asm volatile("sw      $at, 8($sp)");                                          \
+   asm volatile("mfhi    $v0");                                                  \
+   asm volatile("mflo    $v1");                                                  \
+   asm volatile("sw      $v0, 4($sp)");                                          \
+                                                                                 \
+   /* Call ISR */                                                                \
+   asm volatile("la      $t0, _func"#vec);                                       \
+   asm volatile("jalr    $t0");                                                  \
+   asm volatile("sw      $v1, 0($sp)");                                          \
+                                                                                 \
+   /* Pend context switch if needed */                                           \
+   asm volatile("lw      $t0, tn_curr_run_task");                                \
+   asm volatile("lw      $t1, tn_next_task_to_run");                             \
+   asm volatile("lw      $t0, 0($t0)");                                          \
+   asm volatile("lw      $t1, 0($t1)");                                          \
+   asm volatile("lui     $t2, %hi(IFS0SET)");                                    \
+   asm volatile("beq     $t0, $t1, 1f");                                         \
+   asm volatile("ori     $t1, $zero, 2");                                        \
+   asm volatile("sw      $t1, %lo(IFS0SET)($t2)");                               \
+                                                                                 \
+   asm volatile("1:");                                                           \
+   /* Restore registers */                                                       \
+   asm volatile("lw      $v1, 0($sp)");                                          \
+   asm volatile("lw      $v0, 4($sp)");                                          \
+   asm volatile("mtlo    $v1");                                                  \
+   asm volatile("mthi    $v0");                                                  \
+   asm volatile("lw      $at, 8($sp)");                                          \
+   asm volatile("lw      $v0, 12($sp)");                                         \
+   asm volatile("lw      $v1, 16($sp)");                                         \
+   asm volatile("lw      $a0, 20($sp)");                                         \
+   asm volatile("lw      $a1, 24($sp)");                                         \
+   asm volatile("lw      $a2, 28($sp)");                                         \
+   asm volatile("lw      $a3, 32($sp)");                                         \
+   asm volatile("lw      $t0, 36($sp)");                                         \
+   asm volatile("lw      $t1, 40($sp)");                                         \
+   asm volatile("lw      $t2, 44($sp)");                                         \
+   asm volatile("lw      $t3, 48($sp)");                                         \
+   asm volatile("lw      $t4, 52($sp)");                                         \
+   asm volatile("lw      $t5, 56($sp)");                                         \
+   asm volatile("lw      $t6, 60($sp)");                                         \
+   asm volatile("lw      $t7, 64($sp)");                                         \
+   asm volatile("lw      $t8, 68($sp)");                                         \
+   asm volatile("lw      $t9, 72($sp)");                                         \
+   asm volatile("lw      $ra, 76($sp)");                                         \
+                                                                                 \
+   asm volatile("di");                                                           \
+   asm volatile("ehb");                                                          \
+                                                                                 \
+   /* Restore context */                                                         \
+   asm volatile("lw      $k0, 84($sp)");                                         \
+   asm volatile("mtc0    $k0, $14");               /* c0_epc */                  \
+   asm volatile("lw      $k0, 80($sp)");                                         \
+   asm volatile("mtc0    $k0, $12, 2");            /* c0_srsctl */               \
+   asm volatile("addiu   $sp, $sp, 92");                                         \
+                                                                                 \
+   /* Decrease interrupt nesting count */                                        \
+   asm volatile("lui     $k0, %hi(tn_int_nest_count)");                          \
+   asm volatile("lw      $k1, %lo(tn_int_nest_count)($k0)");                     \
+   asm volatile("addiu   $k1, $k1, -1");                                         \
+   asm volatile("sw      $k1, %lo(tn_int_nest_count)($k0)");                     \
+   asm volatile("bne     $k1, $zero, 1f");                                       \
+   asm volatile("lw      $k1, -4($sp)");                                         \
+                                                                                 \
+   /* Swap stack pointers if nesting count is zero */                            \
+   asm volatile("lui     $k0, %hi(tn_int_sp)");                                  \
+   asm volatile("sw      $sp, %lo(tn_int_sp)($k0)");                             \
+   asm volatile("lui     $k0, %hi(tn_user_sp)");                                 \
+   asm volatile("lw      $sp, %lo(tn_user_sp)($k0)");                            \
+                                                                                 \
+   asm volatile("1:");                                                           \
+   asm volatile("wrpgpr  $sp, $sp");                                             \
+   asm volatile("mtc0    $k1, $12");               /* c0_status */               \
+   asm volatile("eret");                                                         \
+                                                                                 \
+   asm volatile(".set reorder");                                                 \
+   asm volatile(".set at");                                                      \
+                                                                                 \
+} __attribute((__noinline__)) void _func##vec(void)
+
+
+
+
+/*----------------------------------------------------------------------------
+ * Interrupt handler wrapper macro for shadow register context saving IPL
+ *----------------------------------------------------------------------------*/
+#define tn_srs_isr(vec)                                                          \
+__attribute__((__noinline__)) void _func##vec(void);                             \
+void __attribute__((naked, nomips16))__attribute__((vector(vec))) _isr##vec(void)\
+{                                                                                \
+   asm volatile(".set mips32r2");                                                \
+   asm volatile(".set nomips16");                                                \
+   asm volatile(".set noreorder");                                               \
+   asm volatile(".set noat");                                                    \
+                                                                                 \
+   asm volatile("rdpgpr  $sp, $sp");                                             \
+                                                                                 \
+   /* Increase interrupt nesting count */                                        \
+   asm volatile("lui     $k0, %hi(tn_int_nest_count)");                          \
+   asm volatile("lw      $k1, %lo(tn_int_nest_count)($k0)");                     \
+   asm volatile("addiu   $k1, $k1, 1");                                          \
+   asm volatile("sw      $k1, %lo(tn_int_nest_count)($k0)");                     \
+   asm volatile("ori     $k0, $zero, 1");                                        \
+   asm volatile("bne     $k1, $k0, 1f");                                         \
+                                                                                 \
+   /* Swap stack pointers if nesting count is one */                             \
+   asm volatile("lui     $k0, %hi(tn_user_sp)");                                 \
+   asm volatile("sw      $sp, %lo(tn_user_sp)($k0)");                            \
+   asm volatile("lui     $k0, %hi(tn_int_sp)");                                  \
+   asm volatile("lw      $sp, %lo(tn_int_sp)($k0)");                             \
+                                                                                 \
+   asm volatile("1:");                                                           \
+   /* Save context on stack */                                                   \
+   asm volatile("addiu   $sp, $sp, -20");                                        \
+   asm volatile("mfc0    $k1, $14");               /* c0_epc */                  \
+   asm volatile("mfc0    $k0, $12, 2");            /* c0_srsctl */               \
+   asm volatile("sw      $k1, 12($sp)");                                         \
+   asm volatile("sw      $k0, 8($sp)");                                          \
+   asm volatile("mfc0    $k1, $12");               /* c0_status */               \
+   asm volatile("sw      $k1, 16($sp)");                                         \
+                                                                                 \
+   /* Enable nested interrupts */                                                \
+   asm volatile("mfc0    $k0, $13");               /* c0_cause */                \
+   asm volatile("ins     $k1, $zero, 1, 15");                                    \
+   asm volatile("ext     $k0, $k0, 10, 6");                                      \
+   asm volatile("ins     $k1, $k0, 10, 6");                                      \
+   asm volatile("mtc0    $k1, $12");               /* c0_status */               \
+                                                                                 \
+   /* Save caller-save registers on stack */                                     \
+   asm volatile("mfhi    $v0");                                                  \
+   asm volatile("mflo    $v1");                                                  \
+   asm volatile("sw      $v0, 4($sp)");                                          \
+                                                                                 \
+   /* Call ISR */                                                                \
+   asm volatile("la      $t0, _func"#vec);                                       \
+   asm volatile("jalr    $t0");                                                  \
+   asm volatile("sw      $v1, 0($sp)");                                          \
+                                                                                 \
+   /* Pend context switch if needed */                                           \
+   asm volatile("lw      $t0, tn_curr_run_task");                                \
+   asm volatile("lw      $t1, tn_next_task_to_run");                             \
+   asm volatile("lw      $t0, 0($t0)");                                          \
+   asm volatile("lw      $t1, 0($t1)");                                          \
+   asm volatile("lui     $t2, %hi(IFS0SET)");                                    \
+   asm volatile("beq     $t0, $t1, 1f");                                         \
+   asm volatile("ori     $t1, $zero, 2");                                        \
+   asm volatile("sw      $t1, %lo(IFS0SET)($t2)");                               \
+                                                                                 \
+   asm volatile("1:");                                                           \
+   /* Restore registers */                                                       \
+   asm volatile("lw      $v1, 0($sp)");                                          \
+   asm volatile("lw      $v0, 4($sp)");                                          \
+   asm volatile("mtlo    $v1");                                                  \
+   asm volatile("mthi    $v0");                                                  \
+                                                                                 \
+   asm volatile("di");                                                           \
+   asm volatile("ehb");                                                          \
+                                                                                 \
+   /* Restore context */                                                         \
+   asm volatile("lw      $k0, 12($sp)");                                         \
+   asm volatile("mtc0    $k0, $14");               /* c0_epc */                  \
+   asm volatile("lw      $k0, 8($sp)");                                          \
+   asm volatile("mtc0    $k0, $12, 2");            /* c0_srsctl */               \
+   asm volatile("addiu   $sp, $sp, 20");                                         \
+                                                                                 \
+   /* Decrease interrupt nesting count */                                        \
+   asm volatile("lui     $k0, %hi(tn_int_nest_count)");                          \
+   asm volatile("lw      $k1, %lo(tn_int_nest_count)($k0)");                     \
+   asm volatile("addiu   $k1, $k1, -1");                                         \
+   asm volatile("sw      $k1, %lo(tn_int_nest_count)($k0)");                     \
+   asm volatile("bne     $k1, $zero, 1f");                                       \
+   asm volatile("lw      $k1, -4($sp)");                                         \
+                                                                                 \
+   /* Swap stack pointers if nesting count is zero */                            \
+   asm volatile("lui     $k0, %hi(tn_int_sp)");                                  \
+   asm volatile("sw      $sp, %lo(tn_int_sp)($k0)");                             \
+   asm volatile("lui     $k0, %hi(tn_user_sp)");                                 \
+   asm volatile("lw      $sp, %lo(tn_user_sp)($k0)");                            \
+                                                                                 \
+   asm volatile("1:");                                                           \
+   asm volatile("wrpgpr  $sp, $sp");                                             \
+   asm volatile("mtc0    $k1, $12");               /* c0_status */               \
+   asm volatile("eret");                                                         \
+                                                                                 \
+   asm volatile(".set reorder");                                                 \
+   asm volatile(".set at");                                                      \
+                                                                                 \
+} __attribute((__noinline__)) void _func##vec(void)
+
 #endif


### PR DESCRIPTION
For me, it is much more useful to have C-language macros instead of assembler macros, because in the case of assembler ones we have to provide separate file with list of my ISRs, so every time I change it I must change it in several places. I keep forgetting about it.

It is better if we have the way to define ISR like this:

``` C
/* Timer 1 interrupt handler using software interrupt context saving */
tn_soft_isr(_TIMER_1_VECTOR)
{
   /* here is your ISR code, including clearing of interrupt flag, and so on */
}
```
